### PR TITLE
Add api setup instructions

### DIFF
--- a/api/development/en.md
+++ b/api/development/en.md
@@ -1,0 +1,95 @@
+# Development
+
+This document will serve as a guide on how to setup a local development environment for the o!TR API.
+
+## Required Dependencies
+
+The following are required to be installed for building the API.
+
+- [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+- [Entity Framework Core 8](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore)
+
+## Setup
+
+### Setting up a PostgreSQL Container
+
+The API requires a PostgreSQL setup to store the database. The easiest way to acomplish this is through [Docker](https://www.docker.com/). Be sure to fill in the relevant fields denoted {VAR}.
+
+```sh
+# Pull the latest PostgreSQL image
+docker pull postgres
+
+# Create and run a container
+docker run --name {CONTAINER_NAME} -e POSTGRES_PASSWORD {PASSWORD} -p 5432:5432 -d postgres
+```
+
+### (Optional) Using the o!TR Demo Database
+
+We have curated a demo database with a few years of tournament data from popular tournaments like OWC. You can choose to use this sample data over starting with an empty database if you wish. You can download the SQL file from [here](). Once downloaded, execute the following commands.
+
+```sh
+# Copy the SQL file to the container
+docker cp demodb.sql {CONTAINER_NAME_OR_ID}:/demodb.sql
+
+# Execute the SQL file with psql
+docker exec -it {CONTAINER_NAME_OR_ID} psql -U {POSTGRES_USER} -d {DATABASE_NAME} -f /demodb.sql
+```
+
+### Configuring the API
+
+Now that you have a PostgreSQL setup and dependencies installed, you are ready to configure and build the API.
+
+Clone the API, and create a config file at `otr-api/API/appsettings.json`. Fill in the values from the `example.appsettings.json` template.
+
+```json
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Trace",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": ""
+  },
+  "Osu": {
+    "ApiKey": "",
+    "ClientId": "",
+    "ClientSecret": "",
+    "AutoUpdateUsers": false,
+    "AllowDataFetching": false
+  },
+  "Jwt": {
+    "Key": "",
+    "Audience": ""
+  },
+  "Auth": {
+    "WebLoginAuthSecret": "",
+    "PrivilegedClientSecret": "",
+    "ClientCallbackUrl": ""
+  }
+}
+```
+
+#### ConnectionStrings
+
+The connection string format is as follows:\
+`"Server={DOMAIN};Port={PORT};User Id={POSTGRES_USER};Password={POSTGRES_PASSWORD};Include Error Detail=true;"`
+
+An example connection string for local development would look like:\
+`"Server=localhost;Port=5432;User Id=postgres;Password=otrdev;Include Error Detail=true;"`
+
+#### Osu
+
+Note that currently the config requires both a v1 osu! API key as well as v2 oath credentials, however the use of the v1 API will be phased out at some point. When creating the oath client, set the redirect url to `localhost:8000/auth`
+
+#### Jwt
+
+The `Key` field is the secret the API uses to encode and decode Jason Web Tokens. You can set this to any random string.
+
+<!-- Needs clarification -->
+The `Audience` field refers to the frontend webserver. You can set this to `"localhost:3000"`.
+
+#### Auth
+
+Need more information

--- a/api/development/en.md
+++ b/api/development/en.md
@@ -67,7 +67,7 @@ Clone the API and create a config file at `otr-api/API/appsettings.Development.j
 }
 ```
 
-#### ConnectionStrings
+#### Connection String
 
 The connection string format is as follows:\
 `"Server=<domain>;Port=<port>;User Id=<postgres_user>;Password=<postgres_password>;Include Error Detail=true;"`

--- a/api/development/en.md
+++ b/api/development/en.md
@@ -13,7 +13,7 @@ The following dependencies are required to be installed for building the API.
 
 ### Setting up a PostgreSQL Container
 
-The API requires a valid PostgreSQL connection to function. The easiest way to accomplish this is through [Docker](https://www.docker.com/). Be sure to fill in the relevant fields denoted `<var_name>`.
+The API requires a valid PostgreSQL connection to function. The easiest way to accomplish this is through [Docker](https://www.docker.com/).
 
 ```sh
 # Pull the latest PostgreSQL image

--- a/api/development/en.md
+++ b/api/development/en.md
@@ -16,10 +16,6 @@ The following dependencies are required to be installed for building the API.
 The API requires a connection to a PostgreSQL database in order to function. The easiest way to accomplish this is through a [Docker](https://www.docker.com/) container.
 
 ```sh
-# Pull the latest PostgreSQL image
-docker pull postgres
-
-# Create and run a container
 docker run -d -p 5432:5432 --name otr-postgres-dev -e POSTGRES_PASSWORD=<some_password> postgres
 ```
 

--- a/api/development/en.md
+++ b/api/development/en.md
@@ -11,23 +11,21 @@ The following dependencies are required to be installed for building the API.
 
 ## Setup
 
-### Setting up a PostgreSQL Container
+### Setting up a PostgreSQL Database
 
-The API requires a valid PostgreSQL connection to function. The easiest way to accomplish this is through [Docker](https://www.docker.com/).
+The API requires a connection to a PostgreSQL database in order to function. The easiest way to accomplish this is through a [Docker](https://www.docker.com/) container.
 
 ```sh
 # Pull the latest PostgreSQL image
 docker pull postgres
 
 # Create and run a container
-docker run -name otr-postgres-dev -e POSTGRES_PASSWORD=<some_password> -p 5432:5432 postgres
+docker run -d -p 5432:5432 --name otr-postgres-dev -e POSTGRES_PASSWORD=<some_password> postgres
 ```
 
 ### Using the o!TR Demo Database
 
-Currently we cannot provide a demo database until the otr-processor is updated. Once we can, this document will be updated.
-
-We curated a demo database containing several years of data from well-known tournaments like OWC. You can download the SQL file from [here](). Once downloaded, execute the following commands.
+*Note: The o!TR Demo Database is not available to the public at this time. This document will be updated once we have a public resource.*
 
 ```sh
 # Copy the SQL file to the container
@@ -39,7 +37,7 @@ docker exec -it <container_name_or_id> psql -U postgres -d postgres -f /demodb.s
 
 ### Configuring the API
 
-With your PostgreSQL setup and dependencies ready, you can now configure and build the API.
+With a fresh PostgreSQL database instance and other required frameworks installed, the API can now be built and configured.
 
 Clone the API and create a config file at `otr-api/API/appsettings.Development.json`. Fill in the values from the `example.appsettings.json` template.
 
@@ -83,14 +81,10 @@ An example connection string for local development would look like:\
 
 #### Osu
 
-Currently the configuration requires both an osu! API v1 key and v2 OAuth2 credentials, however the use of the v1 API will be phased out very soon. When creating the OAuth2 client, the redirect URL is optional. If testing alongside `otr-web`, set the redirect URL to `localhost:3000/auth`.
+Currently the configuration requires both an osu! API v1 key and v2 OAuth2 credentials, however the use of the v1 API will be phased out very soon. When creating the OAuth2 client, the redirect URL is optional. If testing alongside `otr-web`, set the redirect URL to `http://localhost:3000/auth`.
 
 #### Jwt
 
-The `Key` field is the secret the API uses to encode and decode JSON Web Tokens. You can set this to any string.
+The `Key` field is the secret the API uses to encode and decode JSON Web Tokens. This can be set to any string.
 
-The `Audience` field refers to the intended recipient of the JWT. You can set this to any string for development purposes, but in production should be the intended resource server, such as `https://your.production.api.url`.
-
-#### Auth
-
-Need more information
+The `Audience` field refers to the intended recipient of the JWT. This can be set to any string for development purposes, but in production should be the intended resource server, such as `https://some.production.api.url`.

--- a/api/development/en.md
+++ b/api/development/en.md
@@ -1,10 +1,10 @@
 # Development
 
-This document will serve as a guide on how to setup a local development environment for the o!TR API.
+This document serves as a guide on how to setup a local development environment for the o!TR API.
 
 ## Required Dependencies
 
-The following are required to be installed for building the API.
+The following dependencies are required to be installed for building the API.
 
 - [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 - [Entity Framework Core 8](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore)
@@ -13,33 +13,35 @@ The following are required to be installed for building the API.
 
 ### Setting up a PostgreSQL Container
 
-The API requires a PostgreSQL setup to store the database. The easiest way to acomplish this is through [Docker](https://www.docker.com/). Be sure to fill in the relevant fields denoted {VAR}.
+The API requires a valid PostgreSQL connection to function. The easiest way to accomplish this is through [Docker](https://www.docker.com/). Be sure to fill in the relevant fields denoted `<var_name>`.
 
 ```sh
 # Pull the latest PostgreSQL image
 docker pull postgres
 
 # Create and run a container
-docker run --name {CONTAINER_NAME} -e POSTGRES_PASSWORD {PASSWORD} -p 5432:5432 -d postgres
+docker run -name otr-postgres-dev -e POSTGRES_PASSWORD=<some_password> -p 5432:5432 postgres
 ```
 
-### (Optional) Using the o!TR Demo Database
+### Using the o!TR Demo Database
 
-We have curated a demo database with a few years of tournament data from popular tournaments like OWC. You can choose to use this sample data over starting with an empty database if you wish. You can download the SQL file from [here](). Once downloaded, execute the following commands.
+Currently we cannot provide a demo database until the otr-processor is updated. Once we can, this document will be updated.
+
+We curated a demo database containing several years of data from well-known tournaments like OWC. You can download the SQL file from [here](). Once downloaded, execute the following commands.
 
 ```sh
 # Copy the SQL file to the container
-docker cp demodb.sql {CONTAINER_NAME_OR_ID}:/demodb.sql
+docker cp demodb.sql <container_name_or_id>:/demodb.sql
 
 # Execute the SQL file with psql
-docker exec -it {CONTAINER_NAME_OR_ID} psql -U {POSTGRES_USER} -d {DATABASE_NAME} -f /demodb.sql
+docker exec -it <container_name_or_id> psql -U postgres -d postgres -f /demodb.sql
 ```
 
 ### Configuring the API
 
-Now that you have a PostgreSQL setup and dependencies installed, you are ready to configure and build the API.
+With your PostgreSQL setup and dependencies ready, you can now configure and build the API.
 
-Clone the API, and create a config file at `otr-api/API/appsettings.json`. Fill in the values from the `example.appsettings.json` template.
+Clone the API and create a config file at `otr-api/API/appsettings.Development.json`. Fill in the values from the `example.appsettings.json` template.
 
 ```json
 {
@@ -74,21 +76,20 @@ Clone the API, and create a config file at `otr-api/API/appsettings.json`. Fill 
 #### ConnectionStrings
 
 The connection string format is as follows:\
-`"Server={DOMAIN};Port={PORT};User Id={POSTGRES_USER};Password={POSTGRES_PASSWORD};Include Error Detail=true;"`
+`"Server=<domain>;Port=<port>;User Id=<postgres_user>;Password=<postgres_password>;Include Error Detail=true;"`
 
 An example connection string for local development would look like:\
 `"Server=localhost;Port=5432;User Id=postgres;Password=otrdev;Include Error Detail=true;"`
 
 #### Osu
 
-Note that currently the config requires both a v1 osu! API key as well as v2 oath credentials, however the use of the v1 API will be phased out at some point. When creating the oath client, set the redirect url to `localhost:8000/auth`
+Currently the configuration requires both an osu! API v1 key and v2 OAuth2 credentials, however the use of the v1 API will be phased out very soon. When creating the OAuth2 client, the redirect URL is optional. If testing alongside `otr-web`, set the redirect URL to `localhost:3000/auth`.
 
 #### Jwt
 
-The `Key` field is the secret the API uses to encode and decode Jason Web Tokens. You can set this to any random string.
+The `Key` field is the secret the API uses to encode and decode JSON Web Tokens. You can set this to any string.
 
-<!-- Needs clarification -->
-The `Audience` field refers to the frontend webserver. You can set this to `"localhost:3000"`.
+The `Audience` field refers to the intended recipient of the JWT. You can set this to any string for development purposes, but in production should be the intended resource server, such as `https://your.production.api.url`.
 
 #### Auth
 


### PR DESCRIPTION
Add api setup documentation for development

90% finished, need clarification on `JWT.Audience` and `Auth` fields of appsettings

Included a mention of a "demo database" that was previously discussed and the commands to utilize it once we create it.

Feels like it is missing something to me? Maybe ending notes on how to build, run, and run tests?

Closes #7 