### PR TITLE
OAuth documentation

### DIFF
--- a/api/authorization/en.md
+++ b/api/authorization/en.md
@@ -1,2 +1,0 @@
-# Authorization Flow
-

--- a/api/usage/authorization/en.md
+++ b/api/usage/authorization/en.md
@@ -2,4 +2,16 @@
 
 We offer a way for third-party clients to access our API via the OAuth2 standard. Currently, the API is not open for public use. Access will be rolled out in a limited fashion at first before granting broad public usage.
 
-In order to use our API, you must familiarize yourself with our [usage limits](../limits/en.md), else risk being suspended from accessing our API.
+In order to use our API, you must familiarize yourself with our [usage limits](/api/usage/limits/en.md), else risk being suspended from accessing our API.
+
+## Requirements
+- `clientId` - The id of your API client
+- `clientSecret` - The secret phrase assigned to your client.
+
+## Authorize
+
+Authorize your client by calling the [/oauth/token](/api/usage/endpoints/oauth/en.md#authorize-oauth-client) endpoint.
+
+## Refresh
+
+When your API `accessToken` expires, you will need to refresh it using the `refreshToken`. See [/oauth/refresh](/api/usage/endpoints/oauth/en.md#refresh)

--- a/api/usage/authorization/en.md
+++ b/api/usage/authorization/en.md
@@ -1,2 +1,5 @@
 # Authorization Flow
 
+We offer a way for third-party clients to access our API via the OAuth2 standard. Currently, the API is not open for public use. Access will be rolled out in a limited fashion at first before granting broad public usage.
+
+In order to use our API, you must familiarize yourself with our [usage limits](../limits/en.md), else risk being suspended from accessing our API.

--- a/api/usage/authorization/en.md
+++ b/api/usage/authorization/en.md
@@ -8,10 +8,17 @@ In order to use our API, you must familiarize yourself with our [usage limits](/
 - `clientId` - The id of your API client
 - `clientSecret` - The secret phrase assigned to your client.
 
-## Authorize
+## Generate Credentials
 
-Authorize your client by calling the [/oauth/token](/api/usage/endpoints/oauth/en.md#authorize-oauth-client) endpoint.
+Generate access credentials for your client by calling the [/oauth/token](/api/usage/endpoints/oauth/en.md#authorize-oauth-client) endpoint.
 
 ## Refresh
 
 When your API `accessToken` expires, you will need to refresh it using the `refreshToken`. See [/oauth/refresh](/api/usage/endpoints/oauth/en.md#refresh)
+
+## Authorization
+
+Always use the `accessToken` parameter in your `Authorization` header as such.
+
+Header: `Authorization`
+Value: `Bearer <accessToken>`

--- a/api/usage/endpoints/en.md
+++ b/api/usage/endpoints/en.md
@@ -6,9 +6,10 @@ The base URL is: `https://api.otr.stagec.xyz/`
 
 ## List of Documented Routes
 
-- [/beatmaps](./beatmaps/en.md)
-- [/matches](./matches/en.md)
-- [/players](./players/en.md)
+- [/beatmaps](/api/usage/endpoints/beatmaps/en.md)
+- [/matches](/api/usage/endpoints/matches/en.md)
+- [/oauth](/api/usage/endpoints/oauth/en.md)
+- [/players](/api/usage/endpoints/players/en.md)
 
 ## Accept Header
 

--- a/api/usage/endpoints/oauth/en.md
+++ b/api/usage/endpoints/oauth/en.md
@@ -1,0 +1,47 @@
+# OAuth
+
+### Authorize OAuth Client
+
+Authorize an OAuth client, returning access credentials.
+
+Request\
+( **POST** ) `/oauth/token`
+
+Query Parameters\
+`clientId` integer\
+The id of the OAuth client.
+
+`clientSecret` string\
+The secret key assigned to this client.
+
+Example Request
+```js
+fetch("https://api.otr.stagec.xyz/api/v1/oauth/token?clientId=123&clientSecret=abcdefg", {
+  method: "POST",
+});
+```
+
+Response Format\
+Returns [OAuth Response](/api/usage/objects/en.md#oauth-response)
+
+### Refresh
+
+Refresh an expired `accessToken`.
+
+Request\
+( **POST** ) `/oauth/refresh`
+
+Query Parameters\
+`refreshToken` string\
+The refresh token provided when authorizing.
+
+Example Request
+```js
+fetch("https://api.otr.stagec.xyz/api/v1/oauth/refresh?refreshToken=abcdefg", {
+  method: "POST",
+});
+```
+
+Response Format\
+Returns [OAuth Response](/api/usage/objects/en.md#oauth-response), containing a new `accessToken`.
+

--- a/api/usage/endpoints/oauth/en.md
+++ b/api/usage/endpoints/oauth/en.md
@@ -22,7 +22,7 @@ fetch("https://api.otr.stagec.xyz/api/v1/oauth/token?clientId=123&clientSecret=a
 ```
 
 Response Format\
-Returns [OAuth Response](/api/usage/objects/en.md#oauth-response)
+Returns [OAuth Response](/api/usage/objects/en.md#oauthresponse)
 
 ### Refresh
 
@@ -43,5 +43,5 @@ fetch("https://api.otr.stagec.xyz/api/v1/oauth/refresh?refreshToken=abcdefg", {
 ```
 
 Response Format\
-Returns [OAuth Response](/api/usage/objects/en.md#oauth-response), containing a new `accessToken`.
+Returns [OAuthResponse](/api/usage/objects/en.md#oauthresponse), containing a new `accessToken`.
 

--- a/api/usage/limits/en.md
+++ b/api/usage/limits/en.md
@@ -1,0 +1,12 @@
+# API Terms of Use
+
+You should be using the API for good! Please join the [o!TR Discord](https://discord.gg/R53AwX2tJA) and ping Stage for access. You must explain what you plan to use the API for and why we should grant you access. Keep in mind that API access is *extremely* limited at this time.
+
+A few notes from the devs:
+- Do not scrape data from our API / attempt to reconstruct our database. If we suspect this is happening, your access will be blocked permanently.
+- Do not use the API as a means to trick people into thinking your application is an official o!TR application.
+
+
+## Ratelimit
+
+The initial ratelimit will be set to 30 requests per minute. We do not have server capacity to support a huge amount of requests from all users. Specific clients may be given a custom ratelimit on a case-by-case basis. As we learn more about performance, we can look into increasing this limit in the future.

--- a/api/usage/objects/en.md
+++ b/api/usage/objects/en.md
@@ -181,6 +181,16 @@ Represents a mapping of the o!TR match id to its respective osu! match id
 
 ---
 
+### OAuth Response
+
+Represents a set of secrets used for Authorization. Produced after successful OAuth authentication.
+
+| Field     | Type     | Description |
+| :-------- | :------- | :---------- |
+| accessToken | string | This code is used to authorize requests. In all API requests, construct your `Authorization` header as such: `Authorization: Bearer <accessToken>`
+| refreshToken | string | Used by 
+| accessExpiration | integer |
+
 ### Player
 
 Represents a player

--- a/api/usage/objects/en.md
+++ b/api/usage/objects/en.md
@@ -181,15 +181,15 @@ Represents a mapping of the o!TR match id to its respective osu! match id
 
 ---
 
-### OAuth Response
+### OAuthResponse
 
 Represents a set of secrets used for Authorization. Produced after successful OAuth authentication.
 
 | Field     | Type     | Description |
 | :-------- | :------- | :---------- |
-| accessToken | string | This code is used to authorize requests. In all API requests, construct your `Authorization` header as such: `Authorization: Bearer <accessToken>`
-| refreshToken | string | Used by 
-| accessExpiration | integer |
+| accessToken | string | This code is used to authorize requests. In all API requests, construct your `Authorization` header as such: `Authorization: Bearer <accessToken>` |
+| refreshToken | string | A code with a long expiry time that is used to generate a new [OAuthResponse](/api/usage/objects/en.md#oauthresponse) object, containing a new `accessToken` |
+| accessExpiration | integer | Expiration of the `accessToken` in seconds |
 
 ### Player
 


### PR DESCRIPTION
Adds documentation for:

- OAuth /authorize and /refresh endpoints
- Ratelimit and terms of use
- How to use the credentials after authorizing.

Closes #19